### PR TITLE
Add embedded filters middleware abstraction

### DIFF
--- a/src/Middleware/AbstractWorkflowFiltersProvider.php
+++ b/src/Middleware/AbstractWorkflowFiltersProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ObjectivePHP\Application\Middleware;
+
+use ObjectivePHP\Application\Workflow\Filter\FiltersHandler;
+
+/**
+ * Class AbstractFilterableMiddleware
+ *
+ * @package ObjectivePHP\Application\Middleware
+ */
+class AbstractWorkflowFiltersProvider extends AbstractMiddleware implements WorkflowFiltersProviderInterface
+{
+    use FiltersHandler {
+        FiltersHandler::runFilters as runProvidedFilters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function runFilters(): bool
+    {
+        return $this->runProvidedFilters($this->getApplication());
+    }
+}

--- a/src/Middleware/FilteredMiddlewareException.php
+++ b/src/Middleware/FilteredMiddlewareException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ObjectivePHP\Application\Middleware;
+
+/**
+ * Class FilteredMiddlewareException
+ *
+ * @package ObjectivePHP\Application\Middleware
+ */
+class FilteredMiddlewareException extends Exception
+{
+}

--- a/src/Middleware/WorkflowFiltersProviderInterface.php
+++ b/src/Middleware/WorkflowFiltersProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ObjectivePHP\Application\Middleware;
+
+/**
+ * Interface MiddlewareFiltersProviderInterface
+ *
+ * @package ObjectivePHP\Application\Middleware
+ */
+interface WorkflowFiltersProviderInterface extends MiddlewareInterface
+{
+    /**
+     * Run the embedded filters
+     *
+     * @return bool
+     */
+    public function runFilters(): bool;
+}

--- a/tests/Application/AbstractApplicationTest.php
+++ b/tests/Application/AbstractApplicationTest.php
@@ -1,46 +1,44 @@
 <?php
 use ObjectivePHP\Application\AbstractApplication;
 use ObjectivePHP\Application\Config\Param;
+use ObjectivePHP\Application\Middleware\WorkflowFiltersProviderInterface;
 use ObjectivePHP\Events\EventsHandler;
 use ObjectivePHP\PHPUnit\TestCase;
 use ObjectivePHP\ServicesFactory\ServicesFactory;
 
-
 class AbstractApplicationTest extends TestCase
 {
-    
-    
     public function testDefaultEventsHandlerIsInstantiatedOnGet()
     {
         /**
          * @var $application AbstractApplication
          */
         $application = $this->getMockForAbstractClass(AbstractApplication::class);
-        
+
         $eventsHandler = $application->getEventsHandler();
-        
+
         $this->assertInstanceOf(EventsHandler::class, $eventsHandler);
     }
-    
+
     public function testDefaultServicesFactoryIsInstantiatedOnGet()
     {
         /**
          * @var $application AbstractApplication
          */
         $application = $this->getMockForAbstractClass(AbstractApplication::class);
-        
+
         $servicesFactory = $application->getServicesFactory();
-        
+
         $this->assertInstanceOf(ServicesFactory::class, $servicesFactory);
     }
-    
+
     public function testRun()
     {
         /**
          * @var $application AbstractApplication
          */
         $application = $this->getMockForAbstractClass(AbstractApplication::class);
-        
+
         $application->addSteps('test');
         $application->getStep('test')->plug(function ()
         {
@@ -50,17 +48,17 @@ class AbstractApplicationTest extends TestCase
         {
         })->as('second')
         ;
-        
+
         $application->run();
-        
+
         $this->assertCount(2, $application->getExecutionTrace()['test']);
     }
-    
+
     public function testRunFilteredStep()
     {
         /** @var AbstractApplication $app */
         $app = $this->getMockForAbstractClass(AbstractApplication::class);
-        
+
         $app->addSteps('begin', 'end');
         $app->getStep('begin')->plug(function ()
         {
@@ -69,9 +67,9 @@ class AbstractApplicationTest extends TestCase
         $app->getStep('end')->plug(function ()
         {
         })->as('second')->addFilter(function() { return false;});
-        
+
         $app->run();
-        
+
         $this->assertNull($app->getExecutionTrace()['end']);
     }
 
@@ -93,5 +91,42 @@ class AbstractApplicationTest extends TestCase
 
         $this->assertEquals('test.value', $app->getParam('test.param'));
     }
-}
 
+    public function testRunWithMiddlewareFiltersProvider()
+    {
+        /** @var AbstractApplication $app */
+        $app = $this->getMockForAbstractClass(AbstractApplication::class);
+
+        $app->addSteps('test');
+
+        $middleware = $this->getMockBuilder(WorkflowFiltersProviderInterface::class)->getMock();
+        $middleware->expects($this->once())->method('runFilters')->willReturn(true);
+
+        $app->getStep('test')->plug($middleware);
+
+        $app->run();
+
+        $this->assertCount(1, $app->getExecutionTrace()['test']);
+    }
+
+    public function testRunWithFilteredMiddlewareFiltersProvider()
+    {
+        /** @var AbstractApplication $app */
+        $app = $this->getMockForAbstractClass(AbstractApplication::class);
+
+        $app->addSteps('test');
+
+        $middleware = $this->getMockBuilder(WorkflowFiltersProviderInterface::class)->getMock();
+        $middleware->expects($this->once())->method('runFilters')->willReturn(false);
+
+        $app->getStep('test')->plug(function () {
+        });
+        $app->getStep('test')->plug($middleware);
+        $app->getStep('test')->plug(function () {
+        });
+
+        $app->run();
+
+        $this->assertCount(2, $app->getExecutionTrace()['test']);
+    }
+}

--- a/tests/Middleware/AbstractEmbeddedFiltersMiddlewareTest.php
+++ b/tests/Middleware/AbstractEmbeddedFiltersMiddlewareTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Test\ObjectivePHP\Application\Middleware;
+
+use ObjectivePHP\Application\AbstractApplication;
+use ObjectivePHP\Application\Middleware\AbstractWorkflowFiltersProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class AbstractEmbeddedFiltersMiddlewareTest
+ *
+ * @package Test\ObjectivePHP\Application\Middleware
+ */
+class AbstractEmbeddedFiltersMiddlewareTest extends TestCase
+{
+    public function testRunFilterIsExecuted()
+    {
+        /** @var AbstractApplication $app */
+        $app = $this->getMockForAbstractClass(AbstractApplication::class);
+
+        /** @var AbstractWorkflowFiltersProvider $middleware */
+        $middleware = $this->getMockForAbstractClass(AbstractWorkflowFiltersProvider::class);
+        $middleware->setApplication($app);
+
+        $i = 0;
+        $mApp = null;
+        $middleware->addFilter(function ($app) use (&$i, &$mApp) {
+            $mApp = $app;
+            $i++;
+
+            return false;
+        });
+
+        $this->assertFalse($middleware->runFilters());
+        $this->assertEquals($app, $mApp);
+        $this->assertEquals(1, $i);
+    }
+}


### PR DESCRIPTION
Can be useful for defining default filters when you plug a middleware.