### PR TITLE
Clean output buffer before render exception

### DIFF
--- a/src/Operation/ExceptionHandler.php
+++ b/src/Operation/ExceptionHandler.php
@@ -90,6 +90,8 @@ class ExceptionHandler
             </html>
         ';
 
+        // clean buffer before render will prevent an exception from SapiEmitter
+        ob_clean();
 
         // manually emit response
         (new SapiEmitter())->emit((new HtmlResponse($output))->withStatus($code));

--- a/src/Operation/ExceptionHandler.php
+++ b/src/Operation/ExceptionHandler.php
@@ -25,6 +25,9 @@ class ExceptionHandler
     /** @var \Throwable */
     protected $exception;
 
+    /** @var false|string $outputBuffer output buffer content produced before the uncaught exception is thrown */
+    protected $outputBuffer;
+
     public function __construct()
     {
         set_error_handler([$this, 'errorHandler']);
@@ -42,6 +45,7 @@ class ExceptionHandler
     public function __invoke(ApplicationInterface $app)
     {
         $this->app = $app;
+        $this->outputBuffer = ob_get_clean();
         $exception = $this->app->getException();
 
         if ($exception instanceof Exception
@@ -89,9 +93,6 @@ class ExceptionHandler
                             
             </html>
         ';
-
-        // clean buffer before render will prevent an exception from SapiEmitter
-        ob_clean();
 
         // manually emit response
         (new SapiEmitter())->emit((new HtmlResponse($output))->withStatus($code));


### PR DESCRIPTION
A solution for the issue [https://github.com/objective-php/application/issues/6](url). The problem is that the buffer can be not empty when you use SapiEmitter, so you have to clean it.