### PR TITLE
Add routing API an a matching route name

### DIFF
--- a/src/Action/RestfulAction.php
+++ b/src/Action/RestfulAction.php
@@ -6,6 +6,7 @@ namespace ObjectivePHP\Application\Action;
 use ObjectivePHP\Application\Action\HttpAction;
 use ObjectivePHP\Application\Action\SubRoutingAction;
 use Zend\Diactoros\Response\JsonResponse;
+use ObjectivePHP\Primitives\String\Str;
 
 /**
  * Class AbstractRestfulAction
@@ -30,6 +31,16 @@ abstract class RestfulAction extends SubRoutingAction
      */
     public function route()
     {
+        $methodName = (new Str($this->getApplication()->getRequest()->getMatchedRoute()->getName()))
+            ->snakeCase()
+            ->camelCase()
+            ->getInternalValue();
+
+        $callable = $this->getCallable();
+        if (method_exists($callable, $methodName)) {
+            return $methodName;
+        }
+
         $verb = $this->getApplication()->getRequest()->getMethod();
 
         return strtolower($verb);


### PR DESCRIPTION
Use the route identifier as method in the API if the method exists.

If not, the original behaviour is kept.

Example if you have this configuration:

```php
<?php
new FastRoute('get-all-users', '/api/users-all', \Project\Api\UserEndPoints::class)
```

The method `getAllUsers` of the UserVx.php will be called. If the method does not exists, the original `get` method will be called.

PS: needs merge of https://github.com/objective-php/fastroute-package/pull/3 before merging this.