### PR TITLE
WIP for CLI applications

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,19 +1,19 @@
 <?php
 
-    namespace ObjectivePHP\Application;
-    
-    
-    class Exception extends \Exception
-    {
-        // Workflow related
-        const INVALID_EVENT_BINDING = 0x10;
+namespace ObjectivePHP\Application;
 
-        // Action
-        const ACTION_NOT_FOUND = 0x20;
 
-        // Session
-        const SESSION_DISABLED = 0x30;
+class Exception extends \Exception
+{
+    // Workflow related
+    const INVALID_EVENT_BINDING = 0x10;
 
-        // Request parameters
-        const INVALID_PARAMETER_VALUE = 0x40;
-    }
+    // Action
+    const ACTION_NOT_FOUND = 0x20;
+
+    // Session
+    const SESSION_DISABLED = 0x30;
+
+    // Request parameters
+    const INVALID_PARAMETER_VALUE = 0x40;
+}

--- a/src/Workflow/WorkflowEvent.php
+++ b/src/Workflow/WorkflowEvent.php
@@ -18,8 +18,6 @@ class WorkflowEvent extends Event implements WorkflowEventInterface
     use ApplicationAccessorsTrait;
 
     // common
-    const BOOTSTRAP_INIT = 'workflow.bootstrap.init';
-    const BOOTSTRAP_DONE = 'workflow.bootstrap.done';
     const PACKAGES_INIT = 'workflow.packages.init';
     const PACKAGES_READY = 'workflow.packages.ready';
 


### PR DESCRIPTION
I just moved up the common behaviours between HTTPApplication and CLIApplication to AbstractApplication.

I removed the EventHandler from the constructor until we find a way to remove this dead code.
I suggest to pass the EventHandler as second constructor argument.
The work is not done here because it was previously rejected without explainations (https://github.com/objective-php/application/pull/21/files)